### PR TITLE
Fix network error upon creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,5 +40,4 @@ services:
       
 networks:
   wastebin:
-    external:
-      name: wastebin
+    name: wastebin


### PR DESCRIPTION
Compose looks for a pre-existing network when "external" is specified. Removed that so the network will be created with the containers.